### PR TITLE
feat: add facade to get fields in addition to trait way

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,5 +1,5 @@
 {
-    "rules": {
-        "phpdoc_separation": false
-    }
+    "notName": [
+        "ModelFields.php"
+    ]
 }

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "phpdoc_separation": false
+    }
+}

--- a/src/Exceptions/InvalidModelException.php
+++ b/src/Exceptions/InvalidModelException.php
@@ -2,6 +2,4 @@
 
 namespace WatheqAlshowaiter\ModelRequiredFields\Exceptions;
 
-class InvalidModelException extends \InvalidArgumentException
-{
-}
+class InvalidModelException extends \InvalidArgumentException {}

--- a/src/Exceptions/InvalidModelException.php
+++ b/src/Exceptions/InvalidModelException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields\Exceptions;
+
+class InvalidModelException extends \InvalidArgumentException
+{
+}

--- a/src/Exceptions/MissingModelMethodException.php
+++ b/src/Exceptions/MissingModelMethodException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields\Exceptions;
+
+class MissingModelMethodException extends \BadMethodCallException
+{
+}

--- a/src/Exceptions/MissingModelMethodException.php
+++ b/src/Exceptions/MissingModelMethodException.php
@@ -2,6 +2,4 @@
 
 namespace WatheqAlshowaiter\ModelRequiredFields\Exceptions;
 
-class MissingModelMethodException extends \BadMethodCallException
-{
-}
+class MissingModelMethodException extends \BadMethodCallException {}

--- a/src/Exceptions/UnsupportedDatabaseDriverException.php
+++ b/src/Exceptions/UnsupportedDatabaseDriverException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields\Exceptions;
+
+class UnsupportedDatabaseDriverException extends \UnexpectedValueException {}

--- a/src/ModelFields.php
+++ b/src/ModelFields.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields;
+
+use Illuminate\Support\Facades\Facade;
+
+class ModelFields extends Facade
+{
+    /**
+     * @see ModelFieldsService::getRequiredFieldsForOlderVersions()
+     * @method static string[] getRequiredFieldsForOlderVersions($withNullables = false, $withDefaults = false, $withPrimaryKey = false)
+
+     * @see ModelFieldsService::getAllFields()
+     * @method static string[] getAllFields()
+
+     * @see ModelFieldsService::getRequiredFieldsWithDefaults()
+     * @method static string[] getRequiredFieldsWithDefaults()
+
+     * @see ModelFieldsService::getRequiredFieldsWithDefaultsAndPrimaryKey()
+     * @method static string[] getRequiredFieldsWithDefaultsAndPrimaryKey()
+
+     * @see ModelFieldsService::getRequiredFieldsWithNullablesAndDefaults()
+     * @method static string[] getRequiredFieldsWithNullablesAndDefaults()
+
+     * @see ModelFieldsService::getRequiredFieldsWithNullablesAndPrimaryKey()
+     * @method static string[] getRequiredFieldsWithNullablesAndPrimaryKey()
+
+     * @see ModelFieldsService::getRequiredFields()
+     * @method static string[] getRequiredFields($withNullables = false, $withDefaults = false, $withPrimaryKey = false)
+
+     * @see ModelFieldsService::getPrimaryField()
+     * @method static string[] getPrimaryField()
+
+     * @see ModelFieldsService::getRequiredFieldsWithNullables()
+     * @method static string[] getRequiredFieldsWithNullables()
+
+     * @see ModelFieldsService::model()
+     * @method static ModelFieldsService model($modelClass)
+
+     * @see ModelFieldsService::getRequiredFieldsWithPrimaryKey()
+     * @method static string[] getRequiredFieldsWithPrimaryKey()
+     */
+    protected static function getFacadeAccessor(): string
+    {
+        return ModelFieldsService::class;
+    }
+}

--- a/src/ModelFields.php
+++ b/src/ModelFields.php
@@ -8,47 +8,36 @@ class ModelFields extends Facade
 {
     /**
      * @see ModelFieldsService::getRequiredFieldsForOlderVersions()
-     *
      * @method static string[] getRequiredFieldsForOlderVersions($withNullables = false, $withDefaults = false, $withPrimaryKey = false)
      *
      * @see ModelFieldsService::getAllFields()
-     *
      * @method static string[] getAllFields()
      *
      * @see ModelFieldsService::getRequiredFieldsWithDefaults()
-     *
      * @method static string[] getRequiredFieldsWithDefaults()
      *
      * @see ModelFieldsService::getRequiredFieldsWithDefaultsAndPrimaryKey()
-     *
      * @method static string[] getRequiredFieldsWithDefaultsAndPrimaryKey()
      *
      * @see ModelFieldsService::getRequiredFieldsWithNullablesAndDefaults()
-     *
      * @method static string[] getRequiredFieldsWithNullablesAndDefaults()
      *
      * @see ModelFieldsService::getRequiredFieldsWithNullablesAndPrimaryKey()
-     *
      * @method static string[] getRequiredFieldsWithNullablesAndPrimaryKey()
      *
      * @see ModelFieldsService::getRequiredFields()
-     *
      * @method static string[] getRequiredFields($withNullables = false, $withDefaults = false, $withPrimaryKey = false)
      *
      * @see ModelFieldsService::getPrimaryField()
-     *
      * @method static string[] getPrimaryField()
      *
      * @see ModelFieldsService::getRequiredFieldsWithNullables()
-     *
      * @method static string[] getRequiredFieldsWithNullables()
      *
      * @see ModelFieldsService::model()
-     *
      * @method static ModelFieldsService model($modelClass)
      *
      * @see ModelFieldsService::getRequiredFieldsWithPrimaryKey()
-     *
      * @method static string[] getRequiredFieldsWithPrimaryKey()
      */
     protected static function getFacadeAccessor(): string

--- a/src/ModelFields.php
+++ b/src/ModelFields.php
@@ -8,36 +8,47 @@ class ModelFields extends Facade
 {
     /**
      * @see ModelFieldsService::getRequiredFieldsForOlderVersions()
+     *
      * @method static string[] getRequiredFieldsForOlderVersions($withNullables = false, $withDefaults = false, $withPrimaryKey = false)
-
+     *
      * @see ModelFieldsService::getAllFields()
+     *
      * @method static string[] getAllFields()
-
+     *
      * @see ModelFieldsService::getRequiredFieldsWithDefaults()
+     *
      * @method static string[] getRequiredFieldsWithDefaults()
-
+     *
      * @see ModelFieldsService::getRequiredFieldsWithDefaultsAndPrimaryKey()
+     *
      * @method static string[] getRequiredFieldsWithDefaultsAndPrimaryKey()
-
+     *
      * @see ModelFieldsService::getRequiredFieldsWithNullablesAndDefaults()
+     *
      * @method static string[] getRequiredFieldsWithNullablesAndDefaults()
-
+     *
      * @see ModelFieldsService::getRequiredFieldsWithNullablesAndPrimaryKey()
+     *
      * @method static string[] getRequiredFieldsWithNullablesAndPrimaryKey()
-
+     *
      * @see ModelFieldsService::getRequiredFields()
+     *
      * @method static string[] getRequiredFields($withNullables = false, $withDefaults = false, $withPrimaryKey = false)
-
+     *
      * @see ModelFieldsService::getPrimaryField()
+     *
      * @method static string[] getPrimaryField()
-
+     *
      * @see ModelFieldsService::getRequiredFieldsWithNullables()
+     *
      * @method static string[] getRequiredFieldsWithNullables()
-
+     *
      * @see ModelFieldsService::model()
+     *
      * @method static ModelFieldsService model($modelClass)
-
+     *
      * @see ModelFieldsService::getRequiredFieldsWithPrimaryKey()
+     *
      * @method static string[] getRequiredFieldsWithPrimaryKey()
      */
     protected static function getFacadeAccessor(): string

--- a/src/ModelFieldsService.php
+++ b/src/ModelFieldsService.php
@@ -20,7 +20,6 @@ class ModelFieldsService
      * Set up the model class to get fields from
      *
      * @param  class-string<Model>  $modelClass
-     *
      * @return $this
      */
     public function model($modelClass)
@@ -91,7 +90,6 @@ class ModelFieldsService
      * @param  $withNullables  = false
      * @param  $withDefaults  = false
      * @param  $withPrimaryKey  = false
-     *
      * @return string[]
      */
     public function getRequiredFieldsForOlderVersions(

--- a/src/ModelFieldsService.php
+++ b/src/ModelFieldsService.php
@@ -1,0 +1,501 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use WatheqAlshowaiter\ModelRequiredFields\Exceptions\InvalidModelException;
+use WatheqAlshowaiter\ModelRequiredFields\Exceptions\MissingModelMethodException;
+
+class ModelFieldsService
+{
+    /**
+     * @var Model $model
+     */
+    public $model;
+
+    /**
+     * Set up the model class to get fields from
+     *
+     * @param $modelClass
+     *
+     * @return $this
+     */
+    public function model($modelClass)
+    {
+        if (!$this->isEloquentModelClass($modelClass)) {
+            throw new InvalidModelException("Model class must be an instance of Eloquent model");
+        }
+
+        $this->model = $modelClass;
+
+        return $this;
+    }
+
+    /**
+     * Get the required fields that without it we will have a SQL error, not primary,
+     * no nullables, no database or application defaults
+     *
+     * @param $withNullables
+     * @param $withDefaults
+     * @param $withPrimaryKey
+     *
+     * @return array<string>
+     */
+    public function getRequiredFields(
+        $withNullables = false,
+        $withDefaults = false,
+        $withPrimaryKey = false
+    ) {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        if ($this->isLaravelVersionLessThan10()) {
+            return $this->getRequiredFieldsForOlderVersions(
+                $withNullables,
+                $withDefaults,
+                $withPrimaryKey
+            );
+        }
+
+        $modelDefaultAttributes = $this->getModelDefaultAttributes();
+
+        $primaryIndex = $this->getPrimaryField();
+
+        return collect(Schema::getColumns((new $this->model)->getTable()))
+            ->map(function ($column) { // specific to mariadb
+                if ($column['default'] == 'NULL') {
+                    $column['default'] = null;
+                }
+
+                return $column;
+            })
+            ->reject(function ($column) use ($primaryIndex, $withNullables, $withDefaults) {
+                return
+                    $column['nullable'] && !$withNullables ||
+                    $column['default'] != null && !$withDefaults ||
+                    (in_array($column['name'], $primaryIndex));
+            })
+            ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
+                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+            })
+            ->pluck('name')
+            ->when($withPrimaryKey, function ($collection) use ($primaryIndex) {
+                return $collection->prepend(...$primaryIndex);
+            })
+            ->unique()
+            ->toArray();
+    }
+
+    /**
+     * Get the required fields for the old version when not supported from schema
+     * So we need to write an individual query for each SQL database
+     *
+     * @param $withNullables  = false
+     * @param $withDefaults  = false
+     * @param $withPrimaryKey  = false
+     *
+     * @return array<string>
+     */
+    public function getRequiredFieldsForOlderVersions(
+        $withNullables = false,
+        $withDefaults = false,
+        $withPrimaryKey = false
+    ) {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        $databaseDriver = DB::connection()->getDriverName();
+
+        switch ($databaseDriver) {
+            case 'sqlite':
+                return $this->getRequiredFieldsForSqlite(
+                    $withNullables,
+                    $withDefaults,
+                    $withPrimaryKey
+                );
+            case 'mysql':
+            case 'mariadb':
+                return $this->getRequiredFieldsForMysqlAndMariaDb(
+                    $withNullables,
+                    $withDefaults,
+                    $withPrimaryKey
+                );
+            case 'pgsql':
+                return $this->getRequiredFieldsForPostgres(
+                    $withNullables,
+                    $withDefaults,
+                    $withPrimaryKey
+                );
+            case 'sqlsrv':
+                return $this->getRequiredFieldsForSqlServer(
+                    $withNullables,
+                    $withDefaults,
+                    $withPrimaryKey
+                );
+            default:
+                return [
+                    'error' => 'NOT SUPPORTED DATABASE DRIVER'
+                ];
+        }
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredFieldsWithNullables()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields($withNullables = true, $withDefaults = false, $withPrimaryKey = false);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredFieldsWithDefaults()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields($withNullables = false, $withDefaults = true, $withPrimaryKey = false);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredFieldsWithPrimaryKey()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields($withNullables = false, $withDefaults = false, $withPrimaryKey = true);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredFieldsWithDefaultsAndPrimaryKey()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields($withNullables = false, $withDefaults = true, $withPrimaryKey = true);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredFieldsWithNullablesAndDefaults()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields($withNullables = true, $withDefaults = true, $withPrimaryKey = false);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredFieldsWithNullablesAndPrimaryKey()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields($withNullables = true, $withDefaults = false, $withPrimaryKey = true);
+    }
+
+    /**
+     * Get all fields of the model
+     *
+     * @return string[] $array
+     */
+    public function getAllFields()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        return $this->getRequiredFields(
+            $withNullables = true,
+            $withDefaults = true,
+            $withPrimaryKey = true
+        );
+    }
+
+    /**
+     * Get the primary field for the table
+     *
+     * @return array<string>
+     */
+    public function getPrimaryField()
+    {
+        $this->throwIfNotUsingModelMethodFirst();
+
+        $modelTable = (new $this->model)->getTable();
+
+        return collect(Schema::getIndexes($modelTable))
+            ->filter(function ($index) {
+                return $index['primary'];
+            })
+            ->pluck('columns')
+            ->flatten()
+            ->toArray();
+    }
+
+    /**
+     * @param $modelClass
+     *
+     * @return bool
+     */
+    protected function isEloquentModelClass($modelClass)
+    {
+        return is_a($modelClass, Model::class, true);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isLaravelVersionLessThan10()
+    {
+        return (float) App::version() < 10;
+    }
+
+    protected function getRequiredFieldsForSqlite(
+        $withNullables = false,
+        $withDefaults = false,
+        $withPrimaryKey = false
+    ) {
+        $table = $this->getTableFromThisModel();
+        $modelDefaultAttributes = $this->getModelDefaultAttributes();
+
+        $queryResult = DB::select(/** @lang SQLite */ "PRAGMA table_info($table)");
+
+        return collect($queryResult)
+            ->map(function ($column) {
+                return (array) $column;
+            })
+            ->reject(function ($column) use ($withNullables, $withDefaults, $withPrimaryKey) {
+                return $column['pk'] && !$withPrimaryKey
+                    || $column['dflt_value'] != null && !$withDefaults
+                    || !$column['notnull'] && !$withNullables;
+            })
+            ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
+                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+            })
+            ->pluck('name')
+            ->toArray();
+    }
+
+    protected function getRequiredFieldsForMysqlAndMariaDb(
+        $withNullables = false,
+        $withDefaults = false,
+        $withPrimaryKey = false
+    ) {
+        $table = $this->getTableFromThisModel();
+        $modelDefaultAttributes = $this->getModelDefaultAttributes();
+
+        $queryResult = DB::select(
+        /** @lang SQLite */ "
+            SELECT
+                COLUMN_NAME AS name,
+                COLUMN_TYPE AS type,
+                IF(IS_NULLABLE = 'YES', 1, 0) AS nullable,
+                COLUMN_DEFAULT AS `default`,
+                IF(COLUMN_KEY = 'PRI', 1, 0) AS `primary`
+            FROM
+                INFORMATION_SCHEMA.COLUMNS
+            WHERE
+                TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = ?
+            ORDER BY
+                ORDINAL_POSITION ASC",
+            [$table]
+        );
+
+        return collect($queryResult)
+            ->map(function ($column) {
+                return (array) $column;
+            })
+            ->map(function ($column) { // specific to mariadb
+                if ($column['default'] == 'NULL') {
+                    $column['default'] = null;
+                }
+
+                return $column;
+            })
+            ->reject(function ($column) use ($withNullables, $withDefaults, $withPrimaryKey) {
+                return $column['primary'] && !$withPrimaryKey
+                    || $column['default'] != null && !$withDefaults
+                    || $column['nullable'] && !$withNullables;
+            })
+            ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
+                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+            })
+            ->pluck('name')
+            ->toArray();
+    }
+
+    protected function getRequiredFieldsForPostgres(
+        $withNullables = false,
+        $withDefaults = false,
+        $withPrimaryKey = false
+    ) {
+        $table = $this->getTableFromThisModel();
+        $modelDefaultAttributes = $this->getModelDefaultAttributes();
+
+        $primaryIndex = DB::select(/** @lang PostgreSQL */ "
+            SELECT
+                ic.relname AS name,
+                string_agg(a.attname, ',' ORDER BY indseq.ord) AS columns,
+                am.amname AS type,
+                i.indisunique AS unique,
+                i.indisprimary AS primary
+            FROM
+                pg_index i
+                JOIN pg_class tc ON tc.oid = i.indrelid
+                JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+                JOIN pg_class ic ON ic.oid = i.indexrelid
+                JOIN pg_am am ON am.oid = ic.relam
+                JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS indseq(num, ord) ON true
+                LEFT JOIN pg_attribute a ON a.attrelid = i.indrelid
+                AND a.attnum = indseq.num
+            WHERE
+                tc.relname = ?
+                AND tn.nspname = CURRENT_SCHEMA
+            GROUP BY
+                ic.relname,
+                am.amname,
+                i.indisunique,
+                i.indisprimary;
+        ", [$table]);
+
+        $primaryIndex = collect($primaryIndex)
+            ->map(function ($index) {
+                return (array) $index;
+            })
+            ->filter(function ($index) {
+                return $index['primary'];
+            })
+            ->pluck('columns')
+            ->flatten()
+            ->toArray();
+
+        $queryResult = DB::select(
+        /** @lang PostgreSQL */ '
+            SELECT
+                is_nullable AS nullable,
+                column_name AS name,
+                column_default AS default
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = ?
+            ORDER BY
+                ordinal_position ASC',
+            [$table]
+        );
+
+        return collect($queryResult)
+            ->map(function ($column) {
+                return (array) $column;
+            })
+            ->reject(function ($column) use ($primaryIndex, $withDefaults, $withNullables) {
+                return ($column['default'] && !$withDefaults) ||
+                    ($column['nullable'] == 'YES' && !$withNullables) ||
+                    (in_array($column['name'], $primaryIndex));
+            })
+            ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
+                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+            })
+            ->pluck('name')
+            ->when($withPrimaryKey, function ($collection) use ($primaryIndex) {
+                return $collection->prepend(...$primaryIndex);
+            })
+            ->unique()
+            ->toArray();
+    }
+
+    protected function getRequiredFieldsForSqlServer(
+        $withNullables = false,
+        $withDefaults = false,
+        $withPrimaryKey = false
+    ) {
+        $table = $this->getTableFromThisModel();
+        $modelDefaultAttributes = $this->getModelDefaultAttributes();
+
+        $primaryIndex = DB::select(/** @lang TSQL */ '
+            SELECT
+                COL_NAME(ic.object_id, ic.column_id) AS [column]
+            FROM
+                sys.indexes AS i
+                INNER JOIN sys.index_columns AS ic
+                    ON i.object_id = ic.object_id
+                    AND i.index_id = ic.index_id
+                INNER JOIN sys.objects AS o
+                    ON i.object_id = o.object_id
+            WHERE
+                i.is_primary_key = 1
+                AND o.name = ?
+                AND SCHEMA_NAME(o.schema_id) = schema_name()', [$table]);
+
+        $primaryIndex = collect($primaryIndex)
+            ->pluck('column')
+            ->toArray();
+
+        $queryResult = DB::select(
+        /** @lang TSQL */ "
+            SELECT
+                COLUMN_NAME AS name,
+                DATA_TYPE AS type,
+                CASE WHEN IS_NULLABLE = 'YES' THEN 1 ELSE 0 END AS nullable,
+                COLUMN_DEFAULT AS [default]
+            FROM
+                INFORMATION_SCHEMA.COLUMNS
+            WHERE
+                TABLE_SCHEMA = SCHEMA_NAME()
+                AND TABLE_NAME = ?
+            ORDER BY
+                ORDINAL_POSITION ASC",
+            [$table]
+        );
+
+        return collect($queryResult)
+            ->map(function ($column) {
+                return (array) $column;
+            })
+            ->reject(function ($column) use ($withDefaults, $withNullables, $primaryIndex, $withPrimaryKey) {
+                return
+                    $column['default'] != null && !$withDefaults
+                    || $column['nullable'] && !$withNullables
+                    || (in_array($column['name'], $primaryIndex) && !$withPrimaryKey);
+            })
+            ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
+                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+            })
+            ->pluck('name')
+            ->toArray();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTableFromThisModel()
+    {
+        $table = (new $this->model)->getTable();
+
+        return str_replace('.', '__', $table);
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getModelDefaultAttributes()
+    {
+        return array_keys((new $this->model)->getAttributes());
+    }
+
+    /**
+     * @return void
+     */
+    private function throwIfNotUsingModelMethodFirst(): void
+    {
+        if (is_null($this->model)) {
+            throw new MissingModelMethodException("You should use the model method first");
+        }
+    }
+
+}

--- a/src/ModelFieldsService.php
+++ b/src/ModelFieldsService.php
@@ -38,7 +38,7 @@ class ModelFieldsService
      * no nullables, no database or application defaults
      *
      *
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFields(
         $withNullables = false,
@@ -91,7 +91,8 @@ class ModelFieldsService
      * @param  $withNullables  = false
      * @param  $withDefaults  = false
      * @param  $withPrimaryKey  = false
-     * @return array<string>
+     *
+     * @return string[]
      */
     public function getRequiredFieldsForOlderVersions(
         $withNullables = false,
@@ -136,7 +137,7 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFieldsWithNullables()
     {
@@ -146,7 +147,7 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFieldsWithDefaults()
     {
@@ -156,7 +157,7 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFieldsWithPrimaryKey()
     {
@@ -166,7 +167,7 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFieldsWithDefaultsAndPrimaryKey()
     {
@@ -176,7 +177,7 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFieldsWithNullablesAndDefaults()
     {
@@ -186,7 +187,7 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     public function getRequiredFieldsWithNullablesAndPrimaryKey()
     {
@@ -214,7 +215,7 @@ class ModelFieldsService
     /**
      * Get the primary field for the table
      *
-     * @return array<string>
+     * @return string[]
      */
     public function getPrimaryField()
     {
@@ -247,6 +248,9 @@ class ModelFieldsService
         return (float) App::version() < 10;
     }
 
+    /**
+     * @return string[]
+     */
     protected function getRequiredFieldsForSqlite(
         $withNullables = false,
         $withDefaults = false,
@@ -273,6 +277,9 @@ class ModelFieldsService
             ->toArray();
     }
 
+    /**
+     * @return string[]
+     */
     protected function getRequiredFieldsForMysqlAndMariaDb(
         $withNullables = false,
         $withDefaults = false,
@@ -322,6 +329,9 @@ class ModelFieldsService
             ->toArray();
     }
 
+    /**
+     * @return string[]
+     */
     protected function getRequiredFieldsForPostgres(
         $withNullables = false,
         $withDefaults = false,
@@ -402,6 +412,9 @@ class ModelFieldsService
             ->toArray();
     }
 
+    /**
+     * @return string[]
+     */
     protected function getRequiredFieldsForSqlServer(
         $withNullables = false,
         $withDefaults = false,
@@ -474,14 +487,17 @@ class ModelFieldsService
     }
 
     /**
-     * @return array<string>
+     * @return string[]
      */
     protected function getModelDefaultAttributes()
     {
         return array_keys((new $this->model)->getAttributes());
     }
 
-    private function throwIfNotUsingModelMethodFirst(): void
+    /**
+     * @return void
+     */
+    private function throwIfNotUsingModelMethodFirst()
     {
         if (is_null($this->model)) {
             throw new MissingModelMethodException('You should use the model method first');

--- a/src/ModelFieldsService.php
+++ b/src/ModelFieldsService.php
@@ -19,6 +19,7 @@ class ModelFieldsService
     /**
      * Set up the model class to get fields from
      *
+     * @param  class-string<Model>  $modelClass
      *
      * @return $this
      */
@@ -36,7 +37,6 @@ class ModelFieldsService
     /**
      * Get the required fields that without it we will have a SQL error, not primary,
      * no nullables, no database or application defaults
-     *
      *
      * @return string[]
      */

--- a/src/ModelFieldsService.php
+++ b/src/ModelFieldsService.php
@@ -12,21 +12,20 @@ use WatheqAlshowaiter\ModelRequiredFields\Exceptions\MissingModelMethodException
 class ModelFieldsService
 {
     /**
-     * @var Model $model
+     * @var Model
      */
     public $model;
 
     /**
      * Set up the model class to get fields from
      *
-     * @param $modelClass
      *
      * @return $this
      */
     public function model($modelClass)
     {
-        if (!$this->isEloquentModelClass($modelClass)) {
-            throw new InvalidModelException("Model class must be an instance of Eloquent model");
+        if (! $this->isEloquentModelClass($modelClass)) {
+            throw new InvalidModelException('Model class must be an instance of Eloquent model');
         }
 
         $this->model = $modelClass;
@@ -38,9 +37,6 @@ class ModelFieldsService
      * Get the required fields that without it we will have a SQL error, not primary,
      * no nullables, no database or application defaults
      *
-     * @param $withNullables
-     * @param $withDefaults
-     * @param $withPrimaryKey
      *
      * @return array<string>
      */
@@ -73,12 +69,12 @@ class ModelFieldsService
             })
             ->reject(function ($column) use ($primaryIndex, $withNullables, $withDefaults) {
                 return
-                    $column['nullable'] && !$withNullables ||
-                    $column['default'] != null && !$withDefaults ||
+                    $column['nullable'] && ! $withNullables ||
+                    $column['default'] != null && ! $withDefaults ||
                     (in_array($column['name'], $primaryIndex));
             })
             ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
-                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+                return in_array($column['name'], $modelDefaultAttributes) && ! $withDefaults;
             })
             ->pluck('name')
             ->when($withPrimaryKey, function ($collection) use ($primaryIndex) {
@@ -92,10 +88,9 @@ class ModelFieldsService
      * Get the required fields for the old version when not supported from schema
      * So we need to write an individual query for each SQL database
      *
-     * @param $withNullables  = false
-     * @param $withDefaults  = false
-     * @param $withPrimaryKey  = false
-     *
+     * @param  $withNullables  = false
+     * @param  $withDefaults  = false
+     * @param  $withPrimaryKey  = false
      * @return array<string>
      */
     public function getRequiredFieldsForOlderVersions(
@@ -135,7 +130,7 @@ class ModelFieldsService
                 );
             default:
                 return [
-                    'error' => 'NOT SUPPORTED DATABASE DRIVER'
+                    'error' => 'NOT SUPPORTED DATABASE DRIVER',
                 ];
         }
     }
@@ -237,8 +232,6 @@ class ModelFieldsService
     }
 
     /**
-     * @param $modelClass
-     *
      * @return bool
      */
     protected function isEloquentModelClass($modelClass)
@@ -269,12 +262,12 @@ class ModelFieldsService
                 return (array) $column;
             })
             ->reject(function ($column) use ($withNullables, $withDefaults, $withPrimaryKey) {
-                return $column['pk'] && !$withPrimaryKey
-                    || $column['dflt_value'] != null && !$withDefaults
-                    || !$column['notnull'] && !$withNullables;
+                return $column['pk'] && ! $withPrimaryKey
+                    || $column['dflt_value'] != null && ! $withDefaults
+                    || ! $column['notnull'] && ! $withNullables;
             })
             ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
-                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+                return in_array($column['name'], $modelDefaultAttributes) && ! $withDefaults;
             })
             ->pluck('name')
             ->toArray();
@@ -289,7 +282,7 @@ class ModelFieldsService
         $modelDefaultAttributes = $this->getModelDefaultAttributes();
 
         $queryResult = DB::select(
-        /** @lang SQLite */ "
+            /** @lang SQLite */ "
             SELECT
                 COLUMN_NAME AS name,
                 COLUMN_TYPE AS type,
@@ -318,12 +311,12 @@ class ModelFieldsService
                 return $column;
             })
             ->reject(function ($column) use ($withNullables, $withDefaults, $withPrimaryKey) {
-                return $column['primary'] && !$withPrimaryKey
-                    || $column['default'] != null && !$withDefaults
-                    || $column['nullable'] && !$withNullables;
+                return $column['primary'] && ! $withPrimaryKey
+                    || $column['default'] != null && ! $withDefaults
+                    || $column['nullable'] && ! $withNullables;
             })
             ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
-                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+                return in_array($column['name'], $modelDefaultAttributes) && ! $withDefaults;
             })
             ->pluck('name')
             ->toArray();
@@ -375,7 +368,7 @@ class ModelFieldsService
             ->toArray();
 
         $queryResult = DB::select(
-        /** @lang PostgreSQL */ '
+            /** @lang PostgreSQL */ '
             SELECT
                 is_nullable AS nullable,
                 column_name AS name,
@@ -394,12 +387,12 @@ class ModelFieldsService
                 return (array) $column;
             })
             ->reject(function ($column) use ($primaryIndex, $withDefaults, $withNullables) {
-                return ($column['default'] && !$withDefaults) ||
-                    ($column['nullable'] == 'YES' && !$withNullables) ||
+                return ($column['default'] && ! $withDefaults) ||
+                    ($column['nullable'] == 'YES' && ! $withNullables) ||
                     (in_array($column['name'], $primaryIndex));
             })
             ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
-                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+                return in_array($column['name'], $modelDefaultAttributes) && ! $withDefaults;
             })
             ->pluck('name')
             ->when($withPrimaryKey, function ($collection) use ($primaryIndex) {
@@ -437,7 +430,7 @@ class ModelFieldsService
             ->toArray();
 
         $queryResult = DB::select(
-        /** @lang TSQL */ "
+            /** @lang TSQL */ "
             SELECT
                 COLUMN_NAME AS name,
                 DATA_TYPE AS type,
@@ -459,12 +452,12 @@ class ModelFieldsService
             })
             ->reject(function ($column) use ($withDefaults, $withNullables, $primaryIndex, $withPrimaryKey) {
                 return
-                    $column['default'] != null && !$withDefaults
-                    || $column['nullable'] && !$withNullables
-                    || (in_array($column['name'], $primaryIndex) && !$withPrimaryKey);
+                    $column['default'] != null && ! $withDefaults
+                    || $column['nullable'] && ! $withNullables
+                    || (in_array($column['name'], $primaryIndex) && ! $withPrimaryKey);
             })
             ->reject(function ($column) use ($modelDefaultAttributes, $withDefaults) {
-                return in_array($column['name'], $modelDefaultAttributes) && !$withDefaults;
+                return in_array($column['name'], $modelDefaultAttributes) && ! $withDefaults;
             })
             ->pluck('name')
             ->toArray();
@@ -488,14 +481,10 @@ class ModelFieldsService
         return array_keys((new $this->model)->getAttributes());
     }
 
-    /**
-     * @return void
-     */
     private function throwIfNotUsingModelMethodFirst(): void
     {
         if (is_null($this->model)) {
-            throw new MissingModelMethodException("You should use the model method first");
+            throw new MissingModelMethodException('You should use the model method first');
         }
     }
-
 }

--- a/tests/ModelFieldsTest.php
+++ b/tests/ModelFieldsTest.php
@@ -2,7 +2,6 @@
 
 namespace WatheqAlshowaiter\ModelRequiredFields\Tests;
 
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use WatheqAlshowaiter\ModelRequiredFields\Exceptions\InvalidModelException;
 use WatheqAlshowaiter\ModelRequiredFields\Exceptions\MissingModelMethodException;

--- a/tests/ModelFieldsTest.php
+++ b/tests/ModelFieldsTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields\Tests;
+
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use WatheqAlshowaiter\ModelRequiredFields\Exceptions\InvalidModelException;
+use WatheqAlshowaiter\ModelRequiredFields\Exceptions\MissingModelMethodException;
+use WatheqAlshowaiter\ModelRequiredFields\ModelFields;
+use WatheqAlshowaiter\ModelRequiredFields\Tests\Models\Brother;
+use WatheqAlshowaiter\ModelRequiredFields\Tests\Models\Father;
+use WatheqAlshowaiter\ModelRequiredFields\Tests\Models\Grandson;
+use WatheqAlshowaiter\ModelRequiredFields\Tests\Models\Mother;
+use WatheqAlshowaiter\ModelRequiredFields\Tests\Models\Someone;
+use WatheqAlshowaiter\ModelRequiredFields\Tests\Models\Son;
+
+class ModelFieldsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_required_fields_for_father_model()
+    {
+        $this->assertEquals([
+            'name',
+            'email',
+        ], ModelFields::model(Father::class)->getRequiredFields());
+    }
+
+    public function test_get_required_fields_for_father_model_for_older_versions()
+    {
+        $this->assertEquals([
+            'name',
+            'email',
+        ], ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions());
+    }
+
+    public function test_get_required_fields_in_order()
+    {
+        $this->assertNotEquals([
+            'email',
+            'name',
+        ], ModelFields::model(Father::class)->getRequiredFields());
+
+        $this->assertNotEquals([
+            'email',
+            'name',
+        ], ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions());
+    }
+
+    public function test_get_required_fields_with_nullables()
+    {
+        $expected = [
+            'name',
+            'email',
+            'username',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFields($withNullables = true));
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsWithNullables());
+    }
+
+    public function test_get_required_fields_with_nullables_for_older_versions()
+    {
+        $expected = [
+            'name',
+            'email',
+            'username',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+        $this->assertEquals($expected,
+            ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions($withNullables = true));
+    }
+
+    public function test_get_required_fields_with_defaults()
+    {
+        $expected = [
+            'active',
+            'name',
+            'email',
+        ];
+        $this->assertEquals($expected,
+            ModelFields::model(Father::class)->getRequiredFields($withNullables = false, $withDefaults = true));
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions(
+            $withNullables = false,
+            $withDefaults = true
+        ));
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsWithDefaults());
+    }
+
+    public function test_get_required_with_primary_key()
+    {
+        $expected = [
+            'id',
+            'name',
+            'email',
+        ];
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFields(
+            $withNullables = false,
+            $withDefaults = false,
+            $withPrimaryKey = true
+        ));
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions(
+            $withNullables = false,
+            $withDefaults = false,
+            $withPrimaryKey = true
+        ));
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsWithPrimaryKey());
+    }
+
+    public function test_get_required_with_nullables_and_defaults()
+    {
+        $expected = [
+            'active',
+            'name',
+            'email',
+            'username',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFields(
+            $withNullables = true,
+            $withDefaults = true,
+            $withPrimaryKey = false
+        ));
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions(
+            $withNullables = true,
+            $withDefaults = true,
+            $withPrimaryKey = false
+        ));
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsWithNullablesAndDefaults());
+    }
+
+    public function test_get_required_with_nullables_and_primary_key()
+    {
+        $expected = [
+            'id',
+            'name',
+            'email',
+            'username',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFields(
+            $withNullables = true,
+            $withDefaults = false,
+            $withPrimaryKey = true
+        ));
+
+        $this->assertEquals($expected,
+            ModelFields::model(Father::class)->getRequiredFieldsWithNullablesAndPrimaryKey());
+    }
+
+    public function test_get_required_with_nullables_and_primary_key_for_older_versions()
+    {
+        $expected = [
+            'id',
+            'name',
+            'email',
+            'username',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions(
+            $withNullables = true,
+            $withDefaults = false,
+            $withPrimaryKey = true
+        ));
+    }
+
+    public function test_get_required_with_defaults_and_primary_key()
+    {
+        $expected = [
+            'id',
+            'active',
+            'name',
+            'email',
+        ];
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFields(
+            $withNullables = false,
+            $withDefaults = true,
+            $withPrimaryKey = true
+        ));
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions(
+            $withNullables = false,
+            $withDefaults = true,
+            $withPrimaryKey = true
+        ));
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsWithDefaultsAndPrimaryKey());
+    }
+
+    public function test_get_required_with_defaults_and_nullables_and_primary_key()
+    {
+        $expected = [
+            'id',
+            'active',
+            'name',
+            'email',
+            'username',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFields(
+            $withNullables = true,
+            $withDefaults = true,
+            $withPrimaryKey = true
+        ));
+
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getRequiredFieldsForOlderVersions(
+            $withNullables = true,
+            $withDefaults = true,
+            $withPrimaryKey = true
+        ));
+        $this->assertEquals($expected, ModelFields::model(Father::class)->getAllFields());
+    }
+
+    public function test_get_required_fields_for_mother_model()
+    {
+        $this->assertEquals([
+            'uuid',
+            'ulid',
+        ], ModelFields::model(Mother::class)->getRequiredFields());
+    }
+
+    public function test_get_required_fields_for_mother_model_for_older_versions()
+    {
+        $this->assertEquals([
+            'uuid',
+            'ulid',
+        ], ModelFields::model(Mother::class)->getRequiredFieldsForOlderVersions());
+    }
+
+    public function test_get_required_fields_for_son_model()
+    {
+        $this->assertEquals([
+            'father_id',
+        ], ModelFields::model(Son::class)->getRequiredFields());
+    }
+
+    public function test_get_required_fields_for_son_model_for_older_versions()
+    {
+        $this->assertEquals([
+            'father_id',
+        ], ModelFields::model(Son::class)->getRequiredFieldsForOlderVersions());
+    }
+
+    public function test_get_required_fields_excluding_default_model_attributes()
+    {
+        $this->assertEquals([
+            'email',
+        ], ModelFields::model(Brother::class)->getRequiredFields());
+    }
+
+    public function test_get_required_fields_with_applications_defaults()
+    {
+        $expected = [
+            'email',
+            'name',
+        ];
+
+        $this->assertEquals($expected, ModelFields::model(Brother::class)->getRequiredFieldsWithDefaults());
+        $this->assertEquals($expected,
+            ModelFields::model(Brother::class)->getRequiredFields($withNullables = false, $withDefaults = true));
+    }
+
+    public function test_throw_exception_if_model_is_not_extends_of_eloquent_model()
+    {
+        $this->expectException(InvalidModelException::class);
+        $this->expectExceptionMessage('Model class must be an instance of Eloquent model');
+
+        ModelFields::model(Someone::class)->getRequiredFields();
+    }
+
+    public function test_accept_models_that_one_of_the_eloquent_ancestors()
+    {
+        $this->assertequals([], ModelFields::model(Grandson::class)->getRequiredFields());
+    }
+
+    public function test_throw_exception_if_use_get_methods_before_using_model_method()
+    {
+        $this->expectException(MissingModelMethodException::class);
+        $this->expectExceptionMessage('You should use the model method first');
+
+        ModelFields::getRequiredFields();
+    }
+
+    public function test_throw_exception_if_use_get_older_versions_methods_before_using_model_method()
+    {
+        $this->expectException(MissingModelMethodException::class);
+        $this->expectExceptionMessage('You should use the model method first');
+
+        ModelFields::getPrimaryField();
+    }
+}

--- a/tests/ModelFieldsTest.php
+++ b/tests/ModelFieldsTest.php
@@ -286,7 +286,7 @@ class ModelFieldsTest extends TestCase
 
     public function test_accept_models_that_one_of_the_eloquent_ancestors()
     {
-        $this->assertequals([], ModelFields::model(Grandson::class)->getRequiredFields());
+        $this->assertEquals([], ModelFields::model(Grandson::class)->getRequiredFields());
     }
 
     public function test_throw_exception_if_use_get_methods_before_using_model_method()

--- a/tests/Models/Grandson.php
+++ b/tests/Models/Grandson.php
@@ -4,12 +4,6 @@ namespace WatheqAlshowaiter\ModelRequiredFields\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class BaseModel extends Model
-{
+class BaseModel extends Model {}
 
-}
-
-class Grandson extends BaseModel
-{
-
-}
+class Grandson extends BaseModel {}

--- a/tests/Models/Grandson.php
+++ b/tests/Models/Grandson.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BaseModel extends Model
+{
+
+}
+
+class Grandson extends BaseModel
+{
+
+}

--- a/tests/Models/Someone.php
+++ b/tests/Models/Someone.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WatheqAlshowaiter\ModelRequiredFields\Tests\Models;
+
+/**
+ * Not an eloquent model class
+ */
+class Someone
+{
+}

--- a/tests/Models/Someone.php
+++ b/tests/Models/Someone.php
@@ -5,6 +5,4 @@ namespace WatheqAlshowaiter\ModelRequiredFields\Tests\Models;
 /**
  * Not an eloquent model class
  */
-class Someone
-{
-}
+class Someone {}

--- a/todos.md
+++ b/todos.md
@@ -25,3 +25,14 @@
 - [x] fix issues with mariadb database
 - [x] test code for SQL server
 - [x] add GitHub action for all supported SQL databases
+- [x] use facade instead of trait
+- [x] use builder pattern
+- [x] test all the above
+- [x] use model fields instead of required model fields
+- [ ] make the trait @deprecated
+- [ ] use fields() then filter against it
+- [ ] change the readme docs in response to that
+- [ ] in next version remove trait and keep facade
+- [ ] in next version change the whole namespace, github about to model fields
+- [ ] then add methods along the way.. 
+- [ ] add command to get fields like backup-tables


### PR DESCRIPTION
now you can use 

```php
ModelFields::model(User::class)->getRequiredFields()
```

in one way. no two steps like when you add the trait then use it. you can even add classes dynamically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new exception classes for better error handling related to model configurations.
	- Added a service for dynamic handling of required model fields, improving compatibility across various database systems.
	- Implemented a facade for simplified access to model fields.

- **Tests**
	- Added comprehensive tests to validate field extraction and error scenarios, ensuring reliable and robust functionality.
	- Introduced new model classes for testing purposes to cover various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->